### PR TITLE
Lisätty tietopoliittinen ohjelma 2021

### DIFF
--- a/2021/tietopoliittinen-ohjelma.md
+++ b/2021/tietopoliittinen-ohjelma.md
@@ -1,0 +1,475 @@
+Vihreät De Gröna
+
+**Hyväksytty valtuuskunnan kokouksessa 16.5.2021**
+
+# IHMISLÄHTÖINEN JA KESTÄVÄ DIGITALISAATIO
+
+VIHREIDEN TIETOPOLIITTINEN OHJELMA 2021
+
+**Sisällysluettelo**
+
+[JOHDANTO](#johdanto)  
+[TIETOPOLITIIKAN AIKA](#tietopolitiikan-aika)  
+[PARHAALLA TIEDOLLA REILUUN MUUTOKSEEN](#parhaalla-tiedolla-reiluun-muutokseen)  
+[IHMISLÄHTÖISET JULKISET PALVELUT](#ihmislahtoiset-julkiset-palvelut)  
+[DIGITAALINEN TASA-ARVO JA YHDENVERTAISUUS](#digitaalinen-tasaarvo-ja-yhdenvertaisuus)  
+[TURVALLINEN DIGITAALINEN ELÄMÄ](#turvallinen-digitaalinen-elama)  
+[LAADUKKAAN ETÄTEKEMISEN EDELLÄKÄVIJÄ](#laadukkaan-etatekemisen-edellakavija)  
+[DIGITAALINEN IDENTITEETTI JA OMADATA](#digitaalinen-identiteetti-ja-omadata)  
+[HYVINVOINTIA TERVEESTÄ ALUSTATALOUDESTA](#hyvinvointia-terveesta-alustataloudesta)  
+[EETTISESTI KESTÄVÄ TEKOÄLY JA ROBOTIIKKA](#eettisesti-kestava-tekoaly-ja-robotiikka)  
+[DIGITALISAATION YMPÄRISTÖVAIKUTUKSET](#digitalisaation-ymparistovaikutukset)
+
+## JOHDANTO
+
+Digitalisaatio vaikuttaa meihin joka päivä. Se muokkaa yhteiskuntaa nopeasti ja laajasti yhtä aikaa ympäristökriisin, kaupungistumisen, globalisaation sekä väestön vanhenemisen ja moninaistumisen rinnalla. Vahvalla uudella politiikalla varmistetaan, että digitalisaatioon liittyvien muutosten vaikutukset ovat ihmisten ja ympäristön kannalta myönteisiä.
+
+Me vihreät haluamme tukea **ihmislähtöistä digitalisaatiota** ja vakiinnuttaa **tietopolitiikan uudeksi politiikkalohkoksi**. Siinä missä edellisen sadan vuoden aikana Suomeen on luotu nykyisen hyvinvointimme perustaksi työlainsäädännön, peruskoulun ja neuvoloiden kaltaisia instituutioita, on tulevien vuosikymmenten aikana kehitettävä vastaavan tasoisia yhteiskunnallisia ratkaisuja ja ajantasaista lainsäädäntöä tukemaan ja turvaamaan digitalisoituvaa elämää.
+
+Tietopolitiikan ekologisesti kestävä selkäranka on **digitalisaation ympäristövaikutusten tunnistaminen ja tunnustaminen**. Tietopolitiikka mahdollistaa digitalisaation ohjaamisen ja sen vaikutusten huomioimisen päätöksenteossa siten, että sillä rakennetaan parempaa huomista ihmisille ja maapallolle.
+
+Tässä tietopoliittisessa ohjelmassa hahmotellaan vihreän ihmislähtöisen digitalisaation tavoitteet, joissa digitaalisia ratkaisuja hyödynnetään yhteiskunnassa ketterästi ja luovasti kansalaisten tiedollisia oikeuksia, turvallisuutta ja osaamista sekä demokratiaa vahvistaen. Vaikka digitalisaatio määrittää yhä kokonaisvaltaisemmin yhteiskunnan ja ihmisten elämän eri osa-alueita, on yhteiskunnassa pidettävä kiinni keskeisistä perusoikeuksista, laeista ja periaatteista. Näihin kuuluvat tasa-arvo, yhdenvertaisuus, oikeudenmukaisuus, syrjimättömyys, oikeusturva, tietosuoja, tuoteturvallisuus, ihmisten itsemääräämisoikeus, yritysten vapaa kilpailu, kuluttajansuoja, hyvä hallinto, demokratia, yksityisyys ja sananvapaus.
+
+Laajempi taustoitus tässä ohjelmassa esitettyihin tavoitteisiin on julkaistu ajatuspaja Vision kautta: [https://ajatuspajavisio.fi/julkaisut/tietopolitiikka-taustaselvitys/](https://ajatuspajavisio.fi/julkaisut/tietopolitiikka-taustaselvitys/)
+
+## TIETOPOLITIIKAN AIKA
+
+Haluamme vakiinnuttaa **tietopolitiikan uudeksi politiikkalohkoksi**, jolla ohjataan digitalisoituvaa yhteiskuntaa ihmislähtöiseksi ja kestäväksi.
+
+Vastaavalla tavalla kuin ympäristöpolitiikka muodostui omaksi politiikkalohkokseen vihreän liikkeen alkuaikoina, tarvitaan digitalisaation, ennakoimattomien kriisien ja demokratiaa horjuttavan disinformaation aikana kestävää, yli hallituskausien ulottuvaa tietopolitiikkaa. Valtioneuvoston tietopoliittisen selonteon mukaisesti tietopolitiikasta on muodostettava uusi politiikkalohko.
+
+Tietopolitiikan sisällöt ovat poliittisessa keskustelussa vasta hahmottumassa ja osin samoista asioista puhutaan eri käsitteillä, kuten datatalous, teknologiapolitiikka ja digitalisaatio. Tietopolitiikkaan tulee luoda yhteistä kieltä ja sen sisältöjä tulee jäsentää parlamentaarisesti, hallinnonalojen ja yhteiskunnallisten toimijoiden yhteistyönä. Uusi politiikkalohko syntyy systeemisenä muutoksena eri toimijoiden vuorovaikutuksesta. Sisältöjen jäsentämisen ohella on kyettävä uudistamaan rakenteita sellaisiksi, että ne mahdollistavat hyvän tietopolitiikan toteuttamisen. Tietopolitiikka on tulevaisuuteen suuntautuvaa ja liittyy kaikkiin yhteiskunnan aloihin.
+
+**Tietopolitiikkaan keskittyvä ministeriö ja valiokunta**
+
+Tietopolitiikka tarvitsee vastuuministerin ja oman ministeriön. Perustettavan ministeriön tulee olla uudenlainen verkostomainen toimija, joka tukee ja johtaa tietopolitiikan suunnittelua ja toimeenpanoa yhdessä kaikkien hallinnonalojen kanssa. Ministeriö on mahdollista toteuttaa kohtuullisin kustannuksin siirtämällä sen käyttöön virkajärjestelyin digitalisaation ja tietoasioiden parissa nykyisissä ministeriöissä ja niiden alaisissa laitoksissa toimivia henkilöitä. Näillä virkahenkilöillä voidaan tietoisesti säilyttää linkitys aiempiin ministeriöihin ja hallinnonaloihin, jolloin eri toimialojen ymmärrys säilyy ja tiedonkulku on sujuvaa.
+
+Eduskuntaan tulee muodostaa tietopolitiikkaan keskittyvä tietoasiainvaliokunta, joka tukee muiden valiokuntien työtä ja jäsentää muutoin hajanaista tietopoliittista näkemystä lainsäädännön eduskuntakäsittelyssä. Myös tulevaisuusvaliokunnan roolin laajentaminen tulevaisuus- ja tietopoliittiseksi valiokunnaksi voisi palvella samaa päämäärää.
+
+**Tavoitteet:**
+
+*   Perustetaan moderni verkostomaisesti toimiva ministeriö tietopolitiikan hallintorajat ylittävään johtamiseen ja koordinointiin.
+*   Nimitetään hallitukseen tietopolitiikasta vastaava ministeri, jonka tehtävänä on ohjata tietopolitiikkaa.
+*   Muodostetaan eduskuntaan tietopolitiikkaan erikoistunut lausuntovaliokunta, esimerkiksi yhdistetty tulevaisuus- ja tietoasiainvaliokunta, jonka vastuulla on tukea muita valiokuntia tarkastelemalla lakialoitteita tietopoliitiikan näkökulmasta.
+
+**Tietoa koskeva lainsäädäntö ajan tasalle**
+
+Tietoa koskevalla lainsäädännöllä suojataan ja edistetään tiedon avoimuutta ja julkisuutta, tiedollisia oikeuksia, yksityisyyttä ja luotettavan, todistusvoimaisen tiedon saatavuutta, eheyttä ja säilymistä.
+
+Tietolainsäädäntöä on paljon lähtien perustuslaista, julkisuuslaista, sananvapauslaista, tiedonhallintalaista, arkistolaista, EU:n yleisestä tietosuoja-asetuksesta (GDPR) ja tekijänoikeuslaista. Lisäksi erityislainsäädäntöä on runsaasti. EU-sääntely ja kansainväliset sopimukset määrittävät suurta osaa tietolainsäädäntöä.
+
+Digitaalisen tiedon mahdollisuuksia ja riskejä globaalissa toimintaympäristössä on vaikea ennakoida lainsäädännössä. Nykyinen tietolainsäädäntö on pirstaleinen, vaikeaselkoinen ja terminologialtaan epäyhtenäinen. Tämä vaikeuttaa lakien toimeenpanoa ja noudattamista, sekä hidastaa uusien liiketoimintamallien kehittämistä. Lainsäädäntöä tulee kehittää siten, että yleislakeihin perustuen saadaan vakiinnutettua hyvät ja kestävät toimintatavat tiedon hallintaan ja hyödyntämiseen.
+
+**Tavoitteet:**
+
+*   Arvioidaan tietolainsäädännön eettisyyttä, oikeudenmukaisuutta, yhteentoimivuutta ja vaikuttavuutta kokonaisuutena hallituskausittain päivitettävään lainsäädäntöohjelmaan.
+*   Tehdään lainsäädännöstä ymmärrettävää ja yhteentoimivaa. Lainsäädännön valmistelussa on käytettävä kielenhuollon ja terminologian asiantuntemusta.
+*   Laajennetaan tietosuojavaltuutetun toimiston roolia ja rahoitusta tietovaltuutetun toimistoksi, joka olisi kansallinen neuvonta- ja valvontaviranomainen sekä tietosuojalainsäädännön että julkisuuslainsäädännön osalta.
+
+## PARHAALLA TIEDOLLA REILUUN MUUTOKSEEN
+
+Edellytämme **luotettavaa ja avointa tietopohjaa sekä tiedon monipuolista hyödyntämistä** reilun muutoksen tavoitteiden saavuttamiseksi.
+
+Reiluun muutokseen kuuluu avoin, monimuotoinen, eettinen, perusoikeuksia kunnioittava tietokulttuuri, joka mahdollistaa parhaan tiedon hyödyntämisen päätöksenteossa, tutkimuksessa ja tuotekehityksessä, oppimisessa, palveluissa ja kaikessa toiminnassa. Tietovarannot ovat yhteiskunnan toimivuuden, päätöksenteon, demokraattisen digitalisaation ja palvelujen perusta. Hyvälaatuiset ja monipuoliset yhteiskunnan tietovarannot ja tiedon avoin saatavuus on turvattava. Julkisesti rahoitetun tiedon tulee olla, tietosuoja ja muut perustellut rajoitukset huomioiden, mahdollisimman laajasti niin kansalaisten, järjestöjen, yritysten, julkisen hallinnon, tutkijoiden kuin mediankin hyödynnettävissä.
+
+Digitaalinen verkkoympäristö tarjoaa ennennäkemättömät mahdollisuudet tiedon monipuoliseen yhdistämiseen, hyödyntämiseen, ja jakamiseen. Samassa verkkoympäristössä leviää kuitenkin harhaanjohtavaa sisältöä ja eriytyneet informaatiokuplat kaventavat ihmisten näkemystä maailmasta. Seurauksena on yhteiskunnallisen keskustelun rapautumista ja ennakkoasenteiden kiristymistä toisella tavoin ajattelevia kohtaan. Myös tahattomasti väärä, vanhentunut tai vinoutunut, esimerkiksi sukupuolittunut, tieto heikentää toiminnan ja päätöksenteon tietopohjaa. Tekoälyn käytössä vinoutuneet tietoaineistot ovat erityisen suuri riski.
+
+**Tiedon avoimuus ja hyödyntäminen**
+
+Julkishallinnossa avoin data parantaa läpinäkyvyyttä, tehostaa hallintoa ja edistää palvelukehitystä sekä poliittisen päätöksenteon läpinäkyvyyttä ja demokratiaa. Avoimuuden hyödyt säteilevät laajasti yhteiskuntaan, eivät niinkään suorina kustannushyötyinä datan tuottajille. Siksi datan avaaminen tulee sisällyttää ja resurssoida julkishallinnon organisaatioiden perustehtäviin. Huomiota tulee kiinnittää erityisesti yleisen hyödyn kannalta arvokkaisiin tietoaineistoihin. Avaamisessa tulee lisäksi panostaa avoimiin rajapintoihin, jotka on otettava yhdeksi julkishallinnon tietojärjestelmien perusvaatimuksista.
+
+Julkishallinnon kaikilla tasoilla tarvitaan tiedolla johtamista. Julkishallinnon hajanaiset tietojärjestelmät eivät kuitenkaan tue tietomassojen monipuolista hyödyntämistä, eivätkä tietoon perustuvaa päätöksentekoa. Tietovarantojen laatua voidaan parantaa esimerkiksi panostamalla metadataan ja ottamalla käyttöön standardoidut ja avoimet tiedon esitysmuodot sekä yhtenäiset ja tarkoituksenmukaiset sanastomäärittelyt. Tietovarantoja ylläpitävien organisaatioiden toiminta ja tiedonhallinta tulee järjestää niin, että se mahdollistaa laadukkaan avoimen tiedon palvelun.
+
+Avoimuus on myös tutkimuksen ja tieteen perusarvo. Tieteellisen tiedon ja menetelmien avoimuus mahdollistaa tutkimuksen vaikuttavuuden parantamisen sekä tutkimusyhteisössä että yhteiskunnassa. Tieteen, liike-elämän, kansalaisyhteiskunnan ja julkisen hallinnon välistä avointa yhteiskehitystyötä ja datan uudelleenkäyttöä tulee aktiivisesti tukea, jotta voidaan synnyttää tiedepohjaisia oivalluksia globaalien haasteiden ratkaisemiseen. Opetuksen puolella avoimien oppimateriaalien sekä muiden avoimien opetuskäytäntöjen tulee olla osa korkeakoulutuksen arkea, koska ne tukevat kaikkien jatkuvaa oppimista.
+
+**Tavoitteet:**
+
+*   Jatketaan julkisesti rahoitettujen tietovarantojen suunnitelmallista avaamista etenkin tiedon hyödyntämisen kannalta arvokkaiden tietoaineistojen ja avoimien rajapintojen osalta.
+*   Saatetaan julkisesti rahoitetut uudet tutkimusjulkaisut avoimesti saataville. Myös tutkimusaineistojen ja -menetelmien on oltava niin avoimia kuin mahdollista.
+*   Laaditaan julkishallinnon tietovarannoille sitovat laatukriteerit sekä varmistetaan tietovarantojen ja rajapintojen käyttöönotto ja ylläpito riittävällä koulutuksella ja resursseilla.
+
+**Valetiedon vastatoimet**
+
+Valheellisella tai virheellisellä tiedolla on pahimmillaan vakavia vaikutuksia yhteiskuntarauhalle, ihmisten terveydelle ja taloudelle. Esimerkiksi ns. deepfake- eli syväväärennösvideoiden tekeminen uskottaviksi tulee teknologian kehittyessä yhä helpommaksi. Tällä voi olla perustavanlaatuisia vaikutuksia tiedonvälitykseen ja kansalaismielipiteiden muodostukseen. Eri tahot käyttävät aktiivisesti hyväkseen teknisiä välineitä informaation muokkaamiseen haluamakseen.
+
+Väärän ja harhaanjohtavan tiedon syntymistä tulee aktiivisesti estää, koska sen laaja leviäminen on turvallisuusuhka yhteiskunnalle ja yksilöille. Vastavoimia ovat monipuolinen, kriittinen media ja eettinen journalismi, monialainen ja -ammatillinen yhteistyö ja asiantuntijuuden jakaminen, todistusvoimaisen tiedon saatavuus ja säilyttäminen, luotettavan ja tutkitun tiedon avoin ja laaja saatavuus sekä kriittiset kansalaiset, joilla on hyvät tiedon lukutaidot. Näitä valetiedon vastavoimia tulee tukea ja kehittää. Kansalaiset on kasvatettava digitaalisessa ympäristössä toimimiseen ja heidän digi- ja medialukutaitojaan on kehitettävä aina varhaiskasvatuksesta lähtien.
+
+**Tavoitteet:**
+
+*   Käynnistetään kaikki väestöryhmät kattava kansallinen ohjelma vale- ja harhatiedon vastustamiseksi esimerkiksi opetus- ja kulttuuriministeriön alaisuudessa.
+*   Vahvistetaan Ylen ja muiden journalististen medioiden roolia toiminnassa valetietoa vastaan.
+*   Vahvistetaan lasten ja nuorten medialukutaitoja mediakasvatuksella.Tuetaan vanhempia ja huoltajia opastamaan lapsille turvallista medioiden käyttöä ja mediakriittisyyttä.
+
+**Tieto- ja digiosaamisen kehittäminen**
+
+Suomen menestyminen riippuu kansalaisten, yritysten, yhteisöjen ja julkishallinnon kyvystä tuottaa ja hyödyntää tietoa toiminnan jatkuvaan kehittämiseen. Teknologian hyödyntäminen globaalien haasteiden ratkaisemiseen on myös mahdollisuus Suomelle ja esimerkiksi kiertotalouden ja puhtaan teknologian ratkaisujen osaamista kannattaa kehittää. Osaajien saatavuus on kilpailutekijä yrityksille, mutta myös julkishallinnossa tarvitaan tekijöitä digitaalisten palvelujen kehittämiseen ja toiminnan uudistamiseen. Sijoittamalla koulutukseen ja tutkimukseen sekä lisäämällä opiskelu-, työ- ja osaamisperustaista maahanmuuttoa taataan, että osaajia on riittävästi saatavilla kaikille sektoreille. Purkamalla tieto- ja viestintäteknologia-alojen sukupuolittuneisuutta vahvistetaan palkkatasa-arvoa ja monipuolistetaan alan asiantuntijuutta.
+
+Digitalisaation muuttaessa työmarkkinoita edellytykset ja kannustimet uuden oppimiselle luovat pysyvää hyvinvointia. Yhä tärkeämmäksi nousee yksilön ymmärrys omasta osaamisestaan ja kyky täydentää sitä. Yhteiskunnalta työn murrokseen vastaaminen vaatii merkittäviä panostuksia aikuisväestön osaamisen kehittämiseen – on luotava mahdollisuus ja kannusteet jatkuvalle oppimiselle. Suomi tarvitsee tieto- ja digitaitojen perusosaamista koko väestölle sekä monialaista huippuosaamista digitalisaation ja kestävän muutoksen yhdistämiseen. Suomessa digitalisaation parissa toimivien ammattilaisten joukon tulee olla laaja ja taustoiltaan monimuotoinen. Tällä varmistetaan, että digitaalisten palveluiden toteuttamisessa huomioidaan monipuolisesti erilaisten väestöryhmien tarpeet.
+
+**Tavoitteet:**
+
+*   Huolehditaan koulutuksella, jatkuvan oppimisen kannustimilla ja maahantulopolitiikalla, että monipuolisesti eri taustoilta olevia tieto- ja digiosaajia on riittävästi työmarkkinoilla ja yhteiskunnan kaikilla sektoreilla.
+*   Huomioidaan sukupuolinäkökulma kaikessa digitalisaatiopolitiikassa. Vähennetään tieto- ja viestintäteknologia-alojen sukupuolittuneisuutta mm. sukupuolitietoisella kasvatuksella, oppilaanohjauksella ja anonyymillä rekrytoinnilla.
+*   Tarjotaan joustavaa ajasta ja paikasta riippumatonta koulutustarjontaa taantuvilla aloilla työskenteleville ja lisäkoulutusta niille aloille, joilla on suuri kysyntä uusista työntekijöistä, ja joissa teknologia ei voi korvata ihmistyötä.
+
+## IHMISLÄHTÖISET JULKISET PALVELUT
+
+Haluamme, että **julkiset digitaaliset palvelut järjestetään ihmislähtöisesti** ihmisten elämäntapahtumien ja organisaatioiden tapahtumien ympärille.
+
+Digitaalisten julkisten palvelujen tulee olla helposti löytyviä, sujuvia, saavutettavia, turvallisia, virheettömiä ja käyttäjäystävällisiä sekä ohjata palvelun käyttäjää eteenpäin. Hyvät julkiset palvelut ovat osa demokratian ja yhdenvertaisuuden toteutumista. Tiedon ihmislähtöistä hyödyntämistä tulee edistää kaikessa hallinnossa. Se merkitsee viranomaisten tietokäytäntöjen parantamista, palvelujen automatisointia ja tehostamista, niihin pääsyn helpottamista sekä käyttäjien yhdenvertaisuuden vahvistamista.
+
+Ihmisen rooli suhteessa hallintoon ja muihin palveluntuottajiin muuttuu osana digitalisaatiota. Ihmislähtöisyyden periaatteen mukaan kansalainen on aktiivinen omien asioidensa omistaja eikä häntä pidä ajatella vain toiminnan kohteena tai yksittäisten organisaatioiden asiakkaana. Digitaaliset palvelut tulee suunnitella ihmisten, ei niinkään palveluntarjoajien tarpeista.
+
+Ihmisellä on oikeus saada tarvitsemansa palvelut sekä yksityiseltä että julkiselta sektorilta luovuttamatta sellaisia henkilötietojaan, jotka eivät ole välttämättömiä palvelun tarjoamiseksi. Ilman henkilötietojen luovuttamista saatu palvelu ei myöskään saa olla laadun tai hinnan osalta huonompaa. Palvelun käyttäjän on voitava tarkistaa minne tieto päätyy ja mitkä tahot sitä ovat käyttäneet.
+
+**Ihmislähtöisiä kokonaispalveluja kaikkiin elämäntapahtumiin**
+
+Ihmislähtöinen julkisten palvelujen digitalisaatio ottaa huomioon ihmisten yksilöllisen arjen ja helpottaa sitä samalla, kun asioiden hoitamista automatisoidaan. Ihmisen elämässä merkittäviin tapahtumiin liittyvät palvelut tulee tarjota kootusti ja ihmislähtöisesti niin, että asioiden selvittäminen ja hoitaminen tehdään kansalaiselle helpoksi. Myös organisaatioiden asiointia julkishallinnon kanssa tulee järjestää niiden elinkaareen ja toimintaan liittyvien tapahtumien ympärille. Viranomaispalvelujen digitalisoituessa on tärkeää, että palveluketjut muuttuvat nykyistä saumattomammiksi. Vain näin toteutuvat pitkään tavoitellut, byrokratian vähentämiseen tähtäävät yhden luukun ja ‘kysy tietoja vain kerran’ -periaatteet.
+
+Organisaatiorajat ylittävien elämäntapahtumiin liittyvien palvelukokonaisuuksien tuottaminen edellyttää tietojärjestelmiltä yhteentoimivuutta, rajapintoja ja ihmislähtöistä kokonaisarkkitehtuuria ja toimintatapoja. Kulttuurin muutosta julkishallinnossa tulee tukea osoittamalla rahoitusta palvelujen digitalisoinnin ja automatisoinnin ohella myös kokonaisuuksien johtamiseen, uuden toimintakulttuurin rakentamiseen ja uusien taitojen oppimiseen.
+
+**Tavoitteet:**
+
+*   Määritellään julkisten digitalisaatiohankkeiden lähtökohdiksi ihmislähtöisyys ja palvelujen järjestäminen elämäntapahtumien ympärille.
+*   Laajennetaan Digi arkeen -neuvottelukunnan roolia valtakunnalliseksi toimielimeksi tukemaan ja arvioimaan julkishallinnon digitalisaation ihmislähtöisyyttä. Neuvottelukunta kehittää ihmislähtöisen suunnittelun kriteerejä yhteistyössä tutkijoiden ja muiden asiantuntijoiden kanssa.
+*   Tuetaan viranomaisten moniammatillista yhteistyötä mahdollistamalla henkilökohtainen eri viranomaistahojen yhteisesti tuottama palvelusuunnitelma sellaisille ihmisille, jotka tarvitsevat eri toimijoiden tukea omassa elämäntilanteessaan.
+
+**Julkishallinnon tietojärjestelmien kehitysnormit ja avoimuus**
+
+Teknologiaostojen sijaan digitalisaatiohankkeet tulisi nähdä palvelu- ja kehityshankkeina, jotka luonnostaan tarkentuvat matkan varrella. Digihankkeiden hankintaosaamisen tasoa tulee parantaa ja hankintalakia sekä -malleja kehittää joustavammiksi. Palamaisten kertaostojen sijaan tulee suosia hankintamalleja, jotka tarjoavat tarkennusmahdollisuuksia ja skaalautuvuutta kehitystyön edetessä. Samalla tulee välttää toimittajaloukkuja, mutta mahdollistaa pitkäaikaisten kumppanuuksien rakentaminen hyviksi todettujen toimittajien kanssa.
+
+Tekoälyn ja robotiikan avulla julkinen sektori voi samanaikaisesti parantaa tuottavuutta sekä palvelujen laatua ja saatavuutta. Julkisen hallinnon tehtäviä ja palveluja automatisoitaessa on kiinnitettävä huomiota toiminnan läpinäkyvyyteen ja selkeään vastuunjakoon. Digitalisaation edetessä algoritmien merkitys päätöksenteossa kasvaa. Julkishallinnon läpinäkyvyydelle ja luotettavuudelle on kriittistä, että algoritmit lähdekoodeineen ovat avoimia. Myös tekoälyjärjestelmien opetusdatan ja tulosten tulee mahdollisuuksien mukaan olla saatavilla tutkijoille ja kansalaisjärjestöille, jotta kansalaiset voivat arvioida, mihin heitä koskevat päätökset perustuvat.
+
+**Tavoitteet**
+
+*   Uudistetaan hankintalainsäädäntöä, jotta se mahdollistaa palvelujen ja digitalisaation kehityshankkeiden uudelleentarkastelun ja muuttamisen hankkeen aikana sekä toimittajaloukkujen välttämisen. Nostetaan ihmislähtöisyys arviointikriteeriksi digitaalisten kehityshankkeiden hankinnoissa.
+*   Hyödynnetään automaattista päätöksentekoa ja vauhditetaan sääntöpohjaisen automaation, kuten veroehdotusten kaltaisten toiminnallisuuksien käyttöönottoa julkishallinnossa.
+*   Säädetään julkisessa päätöksenteossa käytettävien algoritmien, lähdekoodin ja datan avoimuudesta ja kuulumisesta julkisuuslain piiriin.
+
+#### DIGITAALINEN TASA-ARVO JA YHDENVERTAISUUS
+
+Ohjaamme **yhteiskunnan digitalisoitumista vähentämään eriarvoisuutta.**
+
+Parhaimmillaan digitalisoitumisen myötä työ, koulutus ja monenlainen vapaa-ajan toiminta tulee helpommin kaikkien saataville taustasta riippumatta. Digitalisaatio voi kiihdyttää yhteiskunnallisen eriarvoisuuden lisääntymistä, mikäli ei varmisteta, että kansalaisilla on yhdenvertaiset taidot ja mahdollisuudet sen hyödyntämiseen. Saavutettavuus ja selkeä yleiskieli digipalveluissa sekä fyysisten palvelujen säilyttäminen niitä tarvitseville ovat digiajan yhdenvertaisuutta.
+
+Kirjastoja on kehitettävä digitaalisen tiedon ja kulttuurin peruspalveluna sekä turvallisina ja helposti saavutettavina digi- ja tietotukiympäristöinä. Immateriaalioikeuspolitiikan lähtökohtana tulee olla luovuuteen kannustaminen, teosten käytön edistäminen ja globaali oikeudenmukaisuus.
+
+**Välineet, taidot ja digituki kaikille**
+
+Kansalaisten digitaidot ja niiden tuki on perusedellytys sille, että digitaalisia palveluja voidaan hakea ja käyttää. Tuki digitaitojen oppimiselle sekä toimivat laitteet ja yhteydet ovat välttämättömiä, jotta digitalisaatio kohtelisi kaikkia yhdenvertaisesti. Digipalvelujen on oltava kuitenkin kaikkien saatavilla myös ilman oman digilaitteen tai verkkoyhteyden hankintaa. Politiikan keinoin on tasoitettava tietä niille, joita ei ole tähän asti riittävästi huomioitu digitaalisten palveluiden ja toimintatapojen suunnittelussa.
+
+**Tavoitteet:**
+
+*   Turvataan kuntien rahoitus perus- ja toisella asteella opiskelevien maksuttomiin digilaitteisiin.
+*   Järjestetään eri tasoista opastusta ja tukea digitalisaation hyödyntämiseen eri väestöryhmille.
+*   Määritellään kirjastojen, oppilaitosten ja koulujen tehtäviin digitalisaation hyödyntämisen tuki ja osoitetaan tälle riittävät resurssit.
+
+**Digitaalisten palvelujen saavutettavuus**
+
+Digitaalinen saavutettavuus tulee rinnastaa fyysiseen esteettömyyteen asioinnissa, palveluissa ja yhteiskunnan toiminnoissa. Keskeisten yksityisten ja erityisesti julkisten digipalvelujen saavutettavuutta ja ymmärrettävyyttä on parannettava. Palvelujen vaihteleva taso tai kansalaisten puutteelliset digitaidot eivät saa estää ketään osallistumasta demokraattiseen päätöksentekoon ja yhteiskunnan kehittämiseen. Saavutettavuusdirektiivi ja sitä seuraava kansallinen lainsäädäntö määrittelevät vähimmäistason. Saavutettavuuden toteutumista tulee myös valvoa aktiivisesti ja laiminlyönneistä sanktioida. Julkisen sektorin automaatio mahdollistaa rutiinityön ulkoistamisen koneelle. Säästyneitä resursseja tulee kohdentaa henkilökohtaisiin palveluihin niitä tarvitseville, palvelujen kehittämiseen sekä kansalaisten kohtaamiseen ja heidän yksilöllisten tarpeidensa ymmärtämiseen.
+
+**Tavoitteet:**
+
+*   Sanktioidaan lainsäädännössä saavutettavuuden laiminlyönnit ja sisällytetään saavutettavuuden valvominen asianmukaisen viranomaisen tehtäviin.
+*   Turvataan riittävä rahoitus saavutettavuuden tutkimukselle, valvonnalle, ylläpidolle ja kehittämiselle.
+*   Osoitetaan rahoitusta positiivisen erityiskohtelun periaatteella fyysisiin ja henkilökohtaisiin palveluihin niitä tarvitseville.
+
+**Digitaalisen kulttuurin ja sivistyksen edellytykset kuntoon**
+
+Kirjastojen, arkistojen ja museoiden toimintaedellytykset on turvattava yhteistä kulttuuria ylläpitävinä, jakavina ja säilyttävinä tieto- ja muistiorganisaatioina myös digitaalisessa ympäristössä. Globalisoituvassa mediaympäristössä on erityisen tärkeää ylläpitää ja parantaa kotimaisen tiedon ja kulttuurin tuotantoa ja saatavuutta kaikille asuinpaikasta ja tulotasosta riippumatta.
+
+Tekijänoikeuksiin tarvitaan sekä Suomessa että EU-tasolla reilun käytön sääntelyä kattamaan käyttäjien luoman sisällön ja teosten osittaisen käytön osana kulttuurikritiikkiä tai yhteiskunnallista keskustelua. Luovien alojen edut turvataan parhaiten laillisia palveluja kehittämällä ja niistä luovan työn tekijöille kertyviä tulovirtoja vahvistamalla. Kuluttajaystävällisten ja laillisten verkkopalvelujen kehitys on vähentänyt verkkopiratismia.
+
+**Tavoitteet:**
+
+*   Osoitetaan kunnissa tarvittava rahoitus kirjastojen digisiirtymän toteuttamiseen, jotta sähköisten aineistojen määrä kasvaa huomattavasti.
+*   Kehitetään tekijänoikeuslainsäädäntöä, jotta tekijät saavat e-lainoista vähintään saman korvauksen kuin fyysisistä lainoista, ja jotta e-lainojen keinotekoisista lainausmäärärajoituksista päästään eroon.
+*   Luodaan selkeät oikeudelliset puitteet käyttäjien luomalle sisällölle laajentamalla tekijänoikeuden rajoituksia. Samalla tulee helpottaa teosten käyttölupien hankkimista ja käyttökorvausten maksamista.
+*   Luodaan lainsäädäntö sosiaalisessa mediassa toimivien esiintyjien ja luovan työn tekijöiden ja muiden yhteisöjen ansaintamalleille, kuten sisältömarkkinoinnille sekä rahankeräykselle suoratoiston yhteydessä.
+*   Piratisminvastaisia toimia ei tule ensisijaisesti kohdistaa yksityishenkilöihin, jotka eivät toimi ansaintatarkoituksessa. Piratismista epäiltyjen yhteystietoja luovutetaan oikeudenhaltijoille vain merkittävissä tapauksissa.
+
+## TURVALLINEN DIGITAALINEN ELÄMÄ
+
+Kehitämme **turvallisia digitaalisia toimintaympäristöjä** sekä **parannamme kyberturvallisuutta ja digitaalista huoltovarmuutta** demokratian vahvistamiseksi.
+
+Luottamus viranomaisiin ja toimiva hyvinvointiyhteiskunta ovat kivijalka Suomen sisäiselle turvallisuudelle ja ne tulee säilyttää myös digitaalisessa maailmassa. Digitaalinen elämä ei kuitenkaan rajoitu kansallisvaltioihin. Elämme keskellä kansainvälistä verkkorikollisuutta, informaatiosotaa ja hybridivaikuttamista, joilta suojautuminen on tärkeää.
+
+Digitaalinen turvallisuus on fyysisen turvallisuuden tavoin perusoikeus. Se tarkoittaa, että digitaaliseen toimintaympäristöön voidaan luottaa. Sekä koetun että todellisen turvallisuuden on digitaalisessa ympäristössä oltava yhtä hyvä tai parempi kuin fyysisessä ympäristössä.
+
+Ihmisiä ja yhteisöjä tulee suojata uhkauksilta, painostukselta, väkivallalta ja muulta rikollisuudelta verkossa ja verkon ulkopuolella. Huomioidaan erityisen haavoittavassa asemassa olevat ryhmät kuten lapset, nuoret ja vähemmistöt ja turvataan heidän mahdollisuutensa olla turvassa myös digitaalisessa mediassa. Kun digitaalisuus nyt ja tulevaisuudessa on läsnä lähes kaikessa toiminnassa, myös kyberturvallisuus on keskeinen edellytys toimivalle ja luotettavalle yhteiskunnalle. Terrorismia ja muuta verkkoa hyödyntävää rikollisuutta torjuttaessa käytettävien keinojen on oltava oikeasuhtaisia.
+
+Kaikkea toimivan digitaalisen ympäristön normistoa ei voi määritellä lailla. Yleisten tapojen ja periaatteiden on oltava yhteismitallisia niin fyysisesti kuin verkossakin. Uusissa ja muuttuvissa tilanteissa, joihin ei vielä ole tarkkoja muodollisia sääntöjä, tulisi ihmisten ja organisaatioiden nojautua yleiseen kohtuullisuuden harkintaan sekä kehittää eräänlaista digitaalisen ympäristön yleisiä toiminnan normeja.
+
+**Puututaan digitaaliseen häirintään ja vainoon**
+
+Verkossa tapahtuva häirintä, vihapuhe, uhkailu ja maalittaminen ovat sananvapauden nimissä tapahtuvaa oikeuksien väärinkäyttöä, jolla pyritään vaientamaan ihmisiä. Vaientaminen sulkee eri näkökulmia julkisen keskustelun ulkopuolelle ja siten uhkaa yhteiskuntarauhaa, oikeusvaltion toimintaa ja avointa keskustelua.
+
+Digitaaliseen häirintään ja vainoon on mahdollista puuttua teknologian avulla ja yhteiskunnallisilla toimilla. Ensisijaista on puuttua verkossa tapahtuvien lieveilmiöiden juurisyihin ja ennaltaehkäistä verkkohäirinnän syntymistä. Verkossa tapahtuva häirintä kohdistuu usein sukupuolittuneesti ja vähemmistöihin sekä tiettyihin ammattiryhmiin. Nykyinen lainsäädäntö tarjoaa jo runsaasti keinoja puuttua verkkohäirintään. Näitä välineitä ei kuitenkaan käytetä riittävän tehokkaasti joko viranomaisten asenteista tai resursseista johtuvista syistä.
+
+**Tavoitteet**:
+
+*   Ennaltaehkäistään digitaalista häirintää tuomalla verkkohäirinnän ehkäisy, torjuminen ja jälkihoito tunnetuksi osana opetussuunnitelmia, terveydenhuoltoa ja erilaisten yhteisöjen toimintaa.
+*   Edellytetään sosiaalisen median algoritmisen vihapuheen- ja sisällöntunnistamisen sekä moderointikäytäntöjen avoimuutta ja läpinäkyvyyttä.
+*   Määritellään kansainvälisellä tasolla alustojen vastuut ja velvollisuudet koskien alustoilla tapahtuvaa häirintää ja siihen puuttumista.
+*   Luodaan viranomaisille selkeät ja yhdenmukaiset toimintaohjeet digitaalisen häirinnän ehkäisemiseksi voimassa olevan lainsäädännön puitteissa. Viranomaisilla tulee olla riittävät resurssit sekä osaamista tunnistaa verkkohäirintä ja sen sukupuolittuneisuus sekä tietoa häirintäkokemusten seurauksista.
+*   Tehdään digitaalisessa ympäristössä tapahtuva uhkaaminen vakavalla rikoksella virallisen syytteen alaiseksi rikokseksi.
+*   Tuodaan lainsäädäntöön joukkoistetut rikokset, esimerkiksi ”osallistuminen joukkovainoamiseen”. Joukkoistettujen rikosten on oltava kaikissa tapauksissa virallisen syytteen alaisia.  
+    Puretaan kapeita sukupuolinormeja, jotta nuorten naisten ja vähemmistöjen täysi osallistuminen digitaalisissa tiloissa mahdollistuu.
+
+**Kyberturvallisuus on toimivan yhteiskunnan edellytys**
+
+Yhteiskunnalle kriittisiä palveluja tuottavien organisaatioiden varautuminen kyberhyökkäyksiin ja luonnonkatastrofeihin on usein puutteellista. Kyberturvallisuuden tulee olla sisäänrakennettuna kaikilla yhteiskunnan kriittisillä toimialoilla.
+
+Kyberturvallisuutta voidaan ajatella myös digitaalisen huoltovarmuuden näkökulmasta. Mitä tapahtuu, jos kriittisen järjestelmän palveluntarjoaja yllättäen lopettaa palvelun? Pilvipalvelujen, tekoälyn, kvanttitietokoneiden ja robotiikan osalta EU:n on edistettävä eurooppalaisten yritysten kehitystä ja toimintaedellytyksiä. On panostettava osaamiseen ja tuotekehitykseen sekä taattava tasapuoliset toimintaedellytykset sisämarkkinoilla toimivien eurooppalaisten ja ulkomaisten yritysten välillä.
+
+Tietojärjestelmien lisäksi myös tietoaineistojen tulee olla kunnossa. Koronapandemia on osoittanut esimerkiksi tarpeen ajantasaiselle tiedolle suojatarvikkeiden riittävyydestä ja luettelolle yhteiskunnalle kriittisistä ammateista.
+
+**Tavoitteet:**
+
+*   Vahvistetaan Kyberturvallisuuskeskuksen valtuuksia puuttua kyberturvallisuutta vaarantaviin toimiin ja ilmiöihin.
+*   Lisätään eri toimialoilla kyberturvallisuuden ja tietosuojan viranomaisvalvonnan resursseja, jotta syntyy kokoava johtajuus, yhteinen tilannekuva ja analyysikyky. Keskitytään ennakoivaan valvontaan ja testaamiseen.
+*   Kehitetään julkishallinnon ja yksityisten toimijoiden yhteistyötä niin, että kaikki kriittiset tahot varautuvat paremmin kyberuhkien torjuntaan ja osaavat toimia myös yhdessä.
+*   Kehitetään Euroopan unionin laajuista digitaalista huoltovarmuutta.
+*   Vähennetään EU-maiden riippuvuutta muualla tuotetuista ohjelmistoista, palveluista ja laitteistoista tukemalla eurooppalaisten yritysten kehitystä ja toimintaedellytyksiä.
+*   Määritellään tiedollisen huoltovarmuuden vastuutahot, jotta mahdollisessa kriisitilanteessa on käytettävissä täsmälliset luettelot kriittisistä tietoaineistoista ja että niiden tiedot ovat ajan tasalla.
+
+**Verkkorikollisuutta torjutaan oikeasuhtaisin keinoin**
+
+Terrorismin ja muun verkkoa hyödyntävän rikollisuuden torjuntaa ei tule tehdä yksityisyydensuojan tai sananvapauden kustannuksella. Viranomaisten mahdollisuutta ohittaa salaus ja lukea viestejä viestintäsovelluksissa tulee vastustaa. Rikoksentorjunnan keinona salausteknologioiden heikentäminen ei ole oikeasuhtainen, koska se heikentäisi kaikkien tietoturvaa ja luottamuksellisen tiedon suojaa samalla, kun rikollinen toiminta voisi helposti siirtyä viranomaisvalvonnan ulkopuolisille alustoille. Rikolliset ja vihamieliset valtiot voisivat hyödyntää viranomaisille tarkoitettuja salauksen takaportteja. Kansainvälisiä alustoja koskiessaan käytäntö voisi olla myös kohtalokas esimerkiksi journalistien ja toisinajattelijoiden turvallisuudelle monissa maissa.
+
+EU-tasolla on esitetty palveluntarjoajille velvoitteita poistaa terroristista sisältöä nopealla varoitusajalla. Tällaiset poistovaatimukset sisältävät suuria väärinkäytösriskejä erityisesti oikeusvaltioperiaatteita rikkovissa maissa. Poistovelvoitteiden käytössä tulee noudattaa läpinäkyviä toimintatapoja ja taata osallisten oikeusturva esimerkiksi tarjoamalla mahdollisuus riitauttaa poistovaatimukset.
+
+Pääsyn estäminen kokonaisille verkkosivustoille tulee rajata koskemaan vain tuomioistuimen rikoslain perusteella tapauskohtaisesti laittomaksi toteamia sisältöjä ja niihin liittyvää maksuliikennettä.
+
+**Tavoitteet:**
+
+*   Suomen ei tule hyväksyä salausteknologioita heikentäviä ratkaisuja, kuten esimerkiksi viranomaiskäyttöön tarkoitettuja takaportteja.
+*   Varmistetaan, että EU kantaa globaalia vastuuta tietoturvallisten viestintäkanavien ylläpitämisestä.
+*   Torjutaan palveluntarjoajiin kohdistuvat yleisluontoiset valvontavelvollisuudet. Tiedustelutoiminnassa viestiliikenteen valvonta pidetään tuomioistuimen päätöksillä tarkkaan kohdistettuna.
+*   Varmistetaan oikeusturvan toteutuminen laittomien verkkosisältöjen torjunnassa. Kokonaisten sivustojen estämistä ei tule käyttää ensisijaisena keinona.
+*   Suhtaudutaan pidättyvästi maksuliikenteen rajoittamiseen valtion taholta muun kuin selvästi rikollisen toiminnan kohdalla.
+
+## LAADUKKAAN ETÄTEKEMISEN EDELLÄKÄVIJÄ
+
+Haluamme, että **laadukas etänä tekeminen on kaikille mahdollista** niin työssä, opinnoissa, kansalaistoiminnassa kuin vapaa-ajallakin.
+
+Digitalisoituvassa maailmassa voimme toteuttaa toimivat etätyöolosuhteet ja muut elämän eri osa-alueisiin liittyvät etätekemisen muodot. Etätekeminen ei ole kuitenkaan itseisarvo, vaan se tulee nähdä kansalaisten mahdollisuuksia laajentavana keinona tehdä työtä, kouluttautua, asioida, osallistua kansalaistoimintaan ja harrastaa itselleen parhaiten sopivalla tavalla paikasta riippumatta. Koronapandemia toi näkyväksi etäopiskelun ja etätyöskentelyn mahdollisuudet ja ongelmat. Etätekeminen vähentää matkustamisen päästöjä sekä helpottaa työvoiman liikkuvuutta kotimaassa ja kansainvälisesti, samalla kun se on lisännyt yksinäisyyden tunnetta ja työn kuormitusta.
+
+Hyvän elämän edellytykset koko maassa voidaan turvata etätyöllä ja -opiskelulla sekä tarjoamalla digitaaliset julkiset palvelut helposti myös haja-asutusalueille. Pitämällä Suomen digitaalinen infrastruktuuri toimivana voimme mahdollistaa järjestötoiminnan ja opiskelun kaikkialla sekä tehdä Suomesta houkuttelevan etämaahanmuuttoalueen esimerkiksi kansainvälisten yritysten työntekijöille.
+
+**Etätekemiseen kannustava aluepolitiikka**
+
+Digitalisaatio on jollain tapaa osa lähes kaikkea työtä. Huonot verkkoyhteydet eivät saa rajoittaa etätekemisen mahdollisuuksia. Laajakaistayhteyksien saatavuudessa on Suomessa edelleen puutteita etenkin harvaan asutuilla alueilla. Mobiiliverkkojen toimivuus ei ole kaikkialla tyydyttävä, jolloin ihmiset eivät kykene käyttämään luotettavaa internet-yhteyttä vaativia sähköisiä palveluja. Lakisääteinen laajakaistayhteyden yleispalveluvelvoite määrää teleoperaattorit tarjoamaan jokaiseen asuinkiinteistöön tai yrityksen toimitilaan vähintään 2 Mbit/s:n kohtuuhintaisen tietoliikenneyhteyden. Nykyisille sähköisille palveluille yhteys on kuitenkin liian hidas, joten yleispalveluvelvoitteen nopeusrajaa tulee asteittain nostaa merkittävästi.
+
+Lisäksi tärkeää on parantaa nopeampien valokuituyhteyksien saatavuutta. Asukkaiden ja yritysten lisäksi mobiiliverkkojen tukiasemat hyötyisivät valokuituyhteydestä ja kuituyhteyksien rakentaminen edesauttaisi myös mobiiliverkoissa toimivan yleispalveluvelvoitteen mukaisen minimilaajakaistan kapasiteetin kasvattamista. On löydettävä toimintamalleja, jotka innostavat sekä asukkaat, kunnat, valtion että teleoperaattorit investoimaan maanlaajuisesti yhteyksien parantamiseen.
+
+**Tavoitteet:**
+
+*   Nostetaan lakisääteinen laajakaistan yleispalveluvelvoite asteittain kohti 100 Mbit/s-nopeutta.
+*   Jatketaan ja laajennetaan laajakaistarakentamisen tukiohjelmia, sekä tuetaan kustannustehokasta laajakaistarakentamista esimerkiksi sähköverkon rakentamisen ja tiehankkeiden yhteydessä.
+*   Luodaan puitteet paikkariippumattomalle työnteolle koko julkishallinnossa mm. rakentamalla koko maan kattava yhteisten työpisteiden verkosto.
+
+**Digitaaliset oikeudet työelämässä ja opiskelussa**
+
+Työelämän digitalisoituessa tulee työntekijöistä huolehtia digitalisaation ja etätyöskentelyn muutosten mukaisesti. Työtehtäviä tulee voida hoitaa mahdollisimman laajasti etätyönä. Työntekijöille on taattava oikeus saada ohjausta ja tukea myös etäolosuhteissa.
+
+Työnantajan velvollisuuksien tulee säilyä myös etätöissä, muun muassa ergonomian ja työnohjauksen tarjoamisessa. Etätyö vaatii molemminpuolista luottamusta, mitä selkeyttää asianmukainen työsopimus. Työntekijällä on oltava selkeät velvoitteet, mutta myös oikeudet esimerkiksi sen suhteen, milloin hänen ei tarvitse olla tavoitettavissa.
+
+Perusopetuksen järjestäminen on tiukasti laissa säädetty ja lähtökohtaisesti lähiopetusta. Koronapandemian aikana etäopetus mahdollistettiin tilapäisesti. Saaduista kokemuksista on syytä jalostaa parhaat käytänteet pysyviksi myös lainsäädännön tasolla. Etä- ja lähiopetusta yhdistävä hybridioppiminen luo oppijoille valmiudet itsensä kehittämiseen etäopetuksen ja verkkokurssien avulla yksin ja ryhmissä. Hybridioppimisen edellytykset luo laadukas opetus, jota antavat etäpedagogiset valmiudet omaavat opettajat. Etä- ja hybridioppimisen lähtökohtana tulee aina olla oppimisen hyödyt ja arjen sujuvuus, kuten lasten koulumatkojen pituus, eivät mahdolliset taloudelliset säästöt.
+
+**Tavoitteet:**
+
+*   Velvoitetaan työnantajat sallimaan paikkariippumaton työskentely ja etätyö aina kun se on mahdollista ja tarkoituksenmukaista.
+*   Turvataan lainssäädännöllä kaikille samat oikeudet ja edellytykset etä- ja hybridioppimiseen, myös normaalioloissa, jotta oppijat eivät joudu asuinpaikasta tai muusta tekijästä johtuen eriarvoiseen asemaan.
+*   Tuetaan opettajien mahdollisuuksia ja valmiuksia laadukkaan etäopetuksen tarjoamiseen.
+*   Parannetaan mahdollisuuksia tehdä toisen asteen opintoja etänä muualle hyödyntäen oman kunnan tarjoamia opiskelutiloja.
+
+**Digitaalinen kansalaisyhteiskunta**
+
+Kansalaisyhteiskunnan tärkeä rooli on turvattava myös digitalisoituvassa maailmassa. Suomessa etäosallistumisen tietyissä rajoissa mahdollistava yhdistyslaki on monessa mielessä edistyksellinen. Yhdistyslakia tulee edelleen kehittää niin, että se sallii kokonaan digitaaliset yhdistykset ja yhdistysten perustamisprosessin ja yhdistyksen sisäisen päätöksenteon etänä. Yhdistysten rekisteröinti, tietojen muuttaminen ja ilmoitukset sekä jäsenäänestykset tulee voida tehdä kokonaan digitaalisesti. Kun tämä uudistus tehdään kotimaisia yhdistyksiä varten, samalla kannattaa tähdätä myös houkuttelevaksi kotipaikaksi kansainvälisille järjestöille.
+
+Suomen jäykkä rahankeräyslaki on kansalaistoiminnan este. Rahankeräyslakia tulee muuttaa niin, että se sallii monipuoliset mahdollisuudet myös pienimuotoisen yhdistystoiminnan ja sellaisen verkostomaisen kansalaistoiminnan rahoittamiseen, jolla ei ole taustalla yhdistystä. Lupaprosessin sijaan valvonnan painopistettä tulee siirtää kevyehkön ennakkoilmoittautumisen jälkeen tapahtuvaan toiminnan aikaiseen ja jälkivalvontaan.
+
+**Tavoitteet:**
+
+*   Parannetaan kansalaisyhteiskunnan etätoiminnan edellytyksiä tarjoamalla selkeät ja erilaisilla alustoilla toimivat ohjeet sähköiseen päätöksentekoon, sekä rahoittamalla kansalaisjärjestöjen etäkokouksia ja etäosallistumista sekä digitaalisia varainkeruumahdollisuuksia edistäviä hankkeita.
+*   Tarjotaan julkisena palveluna yhdistyksille ja muuhun ei-kaupalliseen toimintaan etä-äänestämisen ja sähköisen allekirjoittamisen järjestelmät.
+*   Sallitaan yhdistyslaissa kokonaan digitaaliset yhdistykset ja niille sähköinen päätöksenteko sekä poistetaan hallituksen jäsenten asuinpaikan rajoitukset ja mahdollistetaan yhdistyksen rekisteröinti englanninkielisillä säännöillä.
+
+**Luotettavat vaalit**
+
+Vaalit ovat yhteiskunnan kriittistä infrastruktuuria, ja niiden turvallisuus on taattava. Monenlaisten luotettavuuteen, läpinäkyvyyteen ja vaalisalaisuuteen liittyvien ongelmien vuoksi nettiäänestys ei sovi valtakunnallisiin vaaleihin pääasialliseksi äänestystavaksi. Se on vaihtoehto korkeintaan rajattuihin tilanteisiin, ja joidenkin erityisryhmien äänestämiseen. Nettiäänestystä tarvitaan vain tilanteissa, joissa äänioikeutta ei voida toteuttaa esimerkiksi postitse tai avustajien avulla. Nettiäänestys voisi kokeiluluontoisesti sopia myös kunnallisiin neuvoa-antaviin kansanäänestyksiin.
+
+**Tavoitteet:**
+
+*   Eduskunta-, kunta- europarlamentti- ja presidetinvaaleissa ja valtakunnallisissa kansanäänestyksissä ei oteta käyttöön nettiäänestystä. Sitä voidaan kokeilla neuvoa-antavissa kunnallisissa kansanäänestyksissä.
+*   Valmistellaan kunnallisten luottamuselinten ja harkitusti myös eduskunnan toimintaan luotettavia etäosallistumisen menettelyjä.
+*   Ratkaistaan ennakoivasti etäosallistumiseen liittyvien väärinkäytösepäilyjen ja teknisten ongelmien käsittely.
+
+## DIGITAALINEN IDENTITEETTI JA OMADATA
+
+Rakennamme Suomeen **maailman edistyneimmän digitaalisen infrastruktuurin**, jonka keskiössä ovat **ihmislähtöiset digitaalisen identiteetin ja tunnistamisen ratkaisut sekä oikeus omaan tietoon.**
+
+Yleiskäyttöinen digitaalinen infrastruktuuri, joka toimii julkisella ja yksityisellä puolella, on yhteiskunnan perusrakenne, kuten sähkö-, vesi- ja viemäriverkot tai liikenneväylät. Toimivat palvelut vaativat toimivan fyysisen ja digitaalisen infrastruktuurin. Digitaalisen infrastruktuurin ytimessä ovat digitaaliset identiteetit, yksilöivät tunnisteet ja sähköinen tunnistaminen, jotka yhdessä laadukkaiden perusrekisterien kanssa antavat hyvät edellytykset digitalisoida prosesseja niin julkishallinnossa kuin yrityksissäkin.
+
+Digitaalinen identiteetti on palvelussa oleva joukko käyttäjää kuvaavia tietoja, ikään kuin digiversio todellisesta käyttäjästä ja tämän toiminnasta. Yksilöivä tunniste on avain, mihin muita käyttäjän identiteettitietoja voidaan sitoa. Sähköisessä tunnistamisessa käyttäjä osoittaa olevansa palvelussa olevan digitaalisen identiteetin haltija, eli digiversio ja todellinen käyttäjä yhdistetään toisiinsa.
+
+Toimivan sähköisen tunnistamisen ja hyvin tehty henkilötunnuksen uudistus luovat edellytykset turvalliselle ja joustavalle tiedon käsittelylle. Näiden lisäksi tulee kehittää henkilödatan hallintaa omadata-periaatteilla, niin että ihmiset voivat paremmin hallita omia tietojaan ja niiden käyttöä. Jokaisella tulee olla mahdollisuus esiintyä tietoverkoissa anonyymisti tai kuvitteellisella henkilöllisyydellä suojatakseen omaa yksityisyyttään ja ilmaisun vapauttaan.
+
+**Sähköinen tunnistaminen on merkittävä digitaalisen yhteiskunnan perusta**
+
+Sähköisen tunnistamisen kehittämiseltä on puuttunut vastaavien ministeriöiden ja virastojen, sekä pankkien, teleoperaattorien ja muiden sähköisen tunnistamisen kannalta keskeisten toimijoiden yhteinen visio. Suomessa ei ole yleiskäyttöistä tapaa digitaalisesti varmistaa henkilön tai yrityksen tietojen oikeellisuutta, ei mahdollisuutta valtuuttaa henkilöä edustamaan toista ihmistä tai organisaatiota, eikä organisaatioilla ole varmistettua sähköistä identiteettiä. Näiden puutteiden takia monet muuten helposti automatisoitavat prosessit ovat suurelta osin manuaalisia.
+
+Sähköisen tunnistamisen tulee olla edullista palveluntarjoajille ja maksutonta käyttäjille. Tunnistamisvälineiden tulee olla saatavilla muista palveluista erillisinä kaikille, myös alaikäisille ja ulkomaalaisille. Tunnistautumisen tulee olla helppokäyttöistä ja perustoimintojen tulee olla mahdollisia samoilla välineillä niin julkisella kuin yksityiselläkin puolella. Tunnistautumisvälineiden tulee tukea vaihtoehtoja kevyestä vahvaan tunnistamiseen.
+
+Puutteet digitaalisen identiteetin ratkaisuissa tulee korjata pikaisesti ja kohdistaa samalla katse moderneihin, niin sanottuihin itse hallittavan identiteetin (self sovereign identity) ratkaisuihin, joiden suuntaan eurooppalainen sääntely on menossa. Digitaalinen juuri-identiteetti julkisena hyödykkeenä mahdollistaisi markkinaehtoisten, eri tarpeisiin soveltuvien sähköisen tunnistamisen välineiden ja ratkaisujen kehittämisen. Valtio ei saa tehdä tunnistamismonopolia omiin palveluihinsa.
+
+Henkilötunnuksen uudistaminen kannattaa tehdä niin, että nykymallisesta henkilötunnuksesta tulee lähtökohtaisesti salainen tieto, joka voidaan liittää uuteen anonyymiin henkilötunnisteeseen tarvittaessa. Nykyaikaisilla suunnitteluperiaatteilla toteutettu henkilötunniste on merkkijono, joka ei sisällä ikä- tai sukupuolitietoa henkilöstä.
+
+**Tavoitteet:**
+
+*   Taataan, että ihmiset ja organisaatioiden edustajat voivat halutessaan tunnistautua samoilla tunnistautumisvälineillä sekä yksityisiin että julkisiin palveluihin.
+*   Tarjotaan passia tai henkilökorttia vastaava, moderneihin standardeihin pohjautuva digitaalinen juuri-identiteetti julkisena hyödykkeenä kaikille kansalaisille ja täällä pitkäaikaisesti oleskeleville, sekä rekisteröidyille yhteisöille.
+*   Kielletään henkilötunnuksen käyttö tunnistamistarkoituksessa viipymättä ja ohjataan sitä käyttävät tahot esimerkiksi vahvan tunnistamisen käyttäjiksi.
+*   Toteutetaan henkilötunnuksen kokonaisuudistus joustavasti luomalla anonyymien henkilötunnisteiden järjestelmä, jonka rinnalla nykymuotoinen henkilötunnus säilytetään siirtymäajan yli yhtenä tarvittaessa välitettävänä tietona.
+*   Helpotetaan organisaatioiden perustamisvaiheen sähköistä asiointia luomalla organisaatioille digitaalinen identiteetti jo ennen niiden rekisteröintiä.
+
+**Oikeus omaan tietoon**
+
+Tiedollinen itsemääräämisoikeus eli mahdollisuus hyödyntää itse omaa dataansa ja hallita sen keräämistä ja käyttöä on digitaalisen ajan ihmisoikeus. Vastaavalla tavalla, kuin ihmisillä on oikeuksia heitä koskevaan tietoon, tulee organisaatioilla olla oikeus ja mahdollisuus hallita omia tietojaan. Pienten yritysten tiedot voivat olla myös henkilöitä koskevia. Julkisuuslaissa säädettyjen tiedollisten oikeuksien on oltava voimassa myös digitaalisessa muodossa olevien tietojen osalta. Erityisesti julkishallinnon rekistereissä olevaa dataa tulee luovuttaa ihmisten tai organisaatioiden pyynnöstä heille itselleen tai heidän osoittamalleen taholle julkishallinnon peruspalveluna.
+
+Nykyisen vahvan tunnistautumisen luottamusverkoston rinnalle tulee kehittää omadata-operaattoriverkosto. Verkoston avulla kansalaiset voisivat tunnistautumisen yhteydessä antaa asiointipalvelulle luvan hyödyntää hänen tietojaan suoraan muista rekistereistä (esim. ajolupa, pätevyystiedot, opiskelijastatus jne.) ja saada näin palvelukokemuksesta sujuvamman.
+
+**Tavoitteet:**
+
+*   Otetaan käyttöön omadata viranomaispalveluissa sisällyttämällä oikeus omaan tietoon yleislainsäädännön tasolla esimerkiksi julkisuuslakiin ja tiedonhallintalakiin.
+*   Ajetaan EU-tasolla tietosuoja-asetuksen vahvistamista tietojen siirrettävyyden osalta siten, että omat tiedot ovat saatavissa rajapintojen kautta, koskien myös viranomaisten lakisääteisesti keräämiä henkilötietoja.
+*   Laajennetaan tiedollista itsemääräämisoikeutta, esimerkiksi ottamalla käyttöön oikeus pyytää omia terveystietoja poistettaviksi, kun tietoja ei enää tarvita hoidon vuoksi.
+*   Kehitetään vahvistetun datan omadata-operaattoriverkosto, jonka avulla ihmiset ja organisaatiot voivat välittää tietojaan eri palveluihin.
+
+## HYVINVOINTIA TERVEESTÄ ALUSTATALOUDESTA
+
+Haluamme **kehittää alustataloutta avoimuuteen**, **oikeudenmukaisuuteen ja terveeseen kilpailuun ohjaavilla sääntelymekanismeilla**. Alustoja tulee säännellä alustojen keinoilla ja yhteiskunnan ehdoin.
+
+Muulle taloudelliselle ja sosiaaliselle toiminnalle infrastruktuurin tarjoavien alustayhtiöiden yhteiskunnallisia vaikutuksia on seurattava ja tarvittaessa niiden toimintaa on säänneltävä nykyistä selkeämmin ja yhteiskunnan kokonaisetu huomioiden. Sääntelyssä kaikkia digitaalisia alustoja ei kannata eikä voi asettaa samalle viivalle. Alustasääntelyä pohditaan työlainsäädännön, kilpailuoikeuden, tietosuojan ja verotuksen alueilla, ja niihin vaikuttavat samat juurisyyt: globaalisti skaalautuvien digitaalisten alustojen valta-aseman nopea kasvu ja paikkaan sitoutumattomuus, uudenlainen arvonluonti datan avulla sekä taipumus monopolisoituviin markkinoihin.
+
+EU-sääntelyssä ja kansainvälisissä sopimuksissa Suomen tulee ennen kaikkea puolustaa ihmisten digitaalista itsemääräämisoikeutta sekä avointa kilpailuympäristöä, jossa kaikille palveluille on aitoja vaihtoehtoja. Digitaalisen suvereniteetin varjolla tapahtuvaa valtioiden välistä kauppa- ja valtapoliittista kilpavarustelua tulee välttää. Suomen tulee erityisesti nostaa esille ihmislähtöistä näkökulmaa ja linkittää datatalouden ymmärrystä eri alueiden kuten alustatyön, kilpailuoikeuden, tietosuojan ja verotuksen välillä.
+
+Alustatalouteen tulee kehittää uudenlaisia datapohjaisia sääntelymekanismeja, joissa alustoja säännellään alustojen keinoilla, mutta yhteiskunnan ehdoin. Alustat hyödyntävät jatkuvasti kertyvää dataa ja algoritmeja ohjaamaan alustalla tapahtuvaa toimintaa omien tavoitteiden mukaisesti. Samaa datapohjaista lähestymistä voidaan hyödyntää myös yhteiskunnallisten tavoitteiden toteuttamiseen ja seurantaan mahdollistamalla viranomaisille pääsy sääntelyn kannalta keskeiseen dataan alustoilla.
+
+**Alustat ja työ**
+
+Alustatyöhön liittyvä keskeinen kysymys on alustojen ja niiden kautta työtä tekevien valtasuhteiden epätasapaino. Edelläkävijänä Suomen tulee toteuttaa alustojen kautta työtä tekeviä koskevat työelämän turvan parannukset ja mahdollistaa datapohjainen järjestäytyminen.
+
+Itsensätyöllistäjien alivakuuttamista on pyrittävä vähentämään. Kokoluokaltaan merkittävät freelancereita työllistävät alustat tulee velvoittaa kytkeytymään suoraan tulorekisteriin ja tarjoamaan rajapintojen kautta tiedot, joiden avulla vakuutus- ja sosiaaliturvamaksujen sekä verojen maksaminen voidaan automatisoida välitettyjen työkeikkojen mukaisesti. Alustalla toimiva yrittäjä tulee voida joko maksaa velvoitteensa suoraan alustan kautta tai ohjata data johonkin muuhun palveluun kirjanpidon ja maksujen hoitamiseksi.
+
+Alustoihin kohdistuvien vaatimusten on oltavia yhdenmukaisia alustayhtiön kotimaasta riippumatta. Suomen edelläkävijyyden tulee olla osa EU-sääntelyn kehitystä digitaalisilla yhteismarkkinoilla, ei paikalliseksi jäävä kilpailuasetelmia haittaava erityspiirre.
+
+**Tavoitteet:**
+
+*   Taataan yrittäjänä alustatyötä tekeville laillinen järjestäytymisoikeus sekä edellytetään, että alustat avaavat työntekijöille ja heitä edustaville tahoille rajapintojen kautta (ns. worker API) pääsyn kaikkeen heitä koskevaan dataan.
+*   Mahdollistetaan alustan kautta työtä tekevän sosiaaliturvamaksujen tilittäminen siten, että alustayritys voi tilittää ne suoraan palkkionmaksun yhteydessä.
+*   Varmistetaan tarpeellisten tietojen saaminen rajapintojen kautta automaattisesti alustalta viranomaisten ja eläke- ja vakuutusyhtiöiden käyttöön, riippumatta toimiiko alustaa käyttävä tekijä yrityksen, toiminimen tai itseään työllistävän työntekijän roolissa.
+*   Velvoitetaan alustat sopimusmallien läpinäkyvyyteen ja selkeyteen, jotta alustatyön osapuolilla on yhtäläinen ymmärrys toimeksiantoon liittyvästä velvoitteista ja oikeuksista. Säilytetään sopimusvapaus, esimerkiksi neuvottelumahdollisuus palkkioiden suuruudesta, työajoista ja erilaisista muista ehdoista.
+
+**Alustat, kilpailu ja kuluttajansuoja**
+
+Alustoja voidaan säädellä sekä kilpailuoikeudellisesta että kuluttajien oikeuksien näkökulmasta. Kilpailua voidaan lisätä velvoittamalla alustapalvelut noudattamaan yhteentoimivuutta, kuten pankkialalla on EU:ssa jo tehty. Yhteentoimivuussäännösten pitää mahdollistaa kilpailevien ja täydentävien palvelujen rakentamisen alustojen päälle, alustan helpon vaihtamisen ja useiden alustojen samanaikaisen käyttämisen. Kuluttajien oikeuksia vahvistetaan avoimuus- ja läpinäkyvyysvaatimuksilla. Säännösten on oltava riittävän tiukkoja, jotta ne aidosti muuttavat alustojen toimintatapoja. Alustasääntelyn osana ei kuitenkaan pidä ottaa käyttöön massavalvonnaksi katsottavia tietoliikenteen valvontavelvollisuuksia.
+
+**Tavoitteet:**
+
+*   Edellytetään markkina-asemaltaan merkittäviltä alustoilta keskinäistä yhteentoimivuutta.
+*   Luodaan kuluttajien oikeuksia vahvistavat avoimuus- ja läpinäkyvyyssäännökset alustoille.
+
+**Reaaliaikainen talous ja sosiaaliturvan uudistaminen**  
+
+Alustatalous ja työelämän murros haastavat kehittämään sosiaaliturvajärjestelmää joustavammaksi. Mahdollisimman reaaliaikainen ja automaattinen palkkojen, maksujen, verojen ja tukien yhteensovittaminen tukisi sosiaaliturvan käytännön toteutusta. Vihreät on perustulopuolue, jonka mallissa perustulo maksettaisiin automaattisesti ilman byrokratiaa. Perustulo tulee ymmärtää paitsi sosiaaliturvan modernisointina, myös digitalisaatiota hyödyntävänä harppauksena kohti reaaliaikaista talousjärjestelmää. Myös palkanmaksun velvoitteita voidaan merkittävästi helpottaa verotilimallilla. Työnantaja maksaa bruttopalkan kansalaisen verotilille, siitä lasketaan automaattisesti verot, eläkemaksut ja muut sivukulut, ja loput siirretään välittömästi palkansaajan omalle tilille.
+
+Avoimen verotustiedon ja reaaliaikaisen tulorekisterin avulla voidaan tarvittaessa nopeasti reagoida taloutta elvyttämällä tai kiristämällä. Reaaliaikainen tieto maksetuista veroista kertoo myös ihmisten kansantaloudellisesta aktiivisuudesta ja sitä voidaan käyttää tietopohjaiseen päätöksentekoon, kunhan yksityisyyden suojasta huolehditaan. Esimerkiksi automaattisesti tilitettävän kotitalousvähennyksen toteumaa voitaisiin analysoida reaaliajassa ja muutoksia sääntöihin voitaisiin tarvittaessa tehdä nopeastikin. Yritykset ja muut organisaatiot voivat hyödyntää reaaliaikaista sähköistä taloustietoa oman toimintansa tehostamiseen ja keventämään hallinnollista taakkaa. Digitaalinen ja automatisoitu alv-raportointi ja verotusmenettely helpottavat veronmaksua ja harmaan talouden torjuntaa.
+
+**Tavoitteet:**
+
+*   Kehitetään tulorekisteriä ja digitaalista veroinfrastruktuuria kaikki tulomuodot yhteentuovaksi reaaliaikaiseksi alustaksi, joka mahdollistaa sosiaaliturvan modernisoinnin käytännössä.
+*   Automatisoidaan kansalaisten verotilillä palkanmaksuun liittyvien velvoitteiden hoitaminen vastaavalla tavalla kuin yritysten verotilillä on helpotettu yritysten verojen maksua.
+*   Velvoitetaan kaikessa kaupankäynnissä sähköisen laskutusmahdollisuuden ja e-kuitin tarjoamiseen asiakkaan niin halutessa sekä siirrytään automaattiseen ja reaaliaikaiseen arvonlisäverotukseen. Toteutetaan muutokset kohtuullisella siirtymäajalla ja riittävien tukitoimien kanssa siten, etteivät ne kohtuuttomasti rasita yrityksiä.
+*   Selvitetään tukien ja verovähennysten reaaliaikaisen ja automatisoidun maksatuksen mahdollisuuksia tapauksissa, joissa päätökset voidaan toteuttaa sääntöpohjaisesti rekisteritietojen perusteella.
+
+## EETTISESTI KESTÄVÄ TEKOÄLY JA ROBOTIIKKA
+
+Haluamme **tekoälyn avulla ratkoa sosiaalisesti ja ekologisesti kestävän yhteiskunnan kannalta merkityksellisiä haasteita**.
+
+Tekoälyyn, robotiikkaan ja automaatioon liittyy suuria mahdollisuuksia. Samalla näihin teknologioihin liittyy merkittäviä vallankäytön ja eettisen toiminnan kysymyksiä, joihin tarvitaan vastauksia ennen kuin koko yhteiskunta toimii tekoälyjen ja robottien varassa.
+
+Tekoälyjärjestelmät tulee suunnitella täydentämään ja vahvistamaan ihmisten kognitiivisia, sosiaalisia, kulttuurisia ja luovia taitoja sekä noudattamaan ihmislähtöisyyden periaatteita. Samalla kun automaatiota otetaan avuksi yhteiskunnan polttavien ongelmien ratkomiseen, on turvattava yksilönvapaudet ja yksityisyys sekä varmistettava, että tekoälyn käytöllä kokonaisuudessaan on myös ympäristön kannalta myönteinen vaikutus. Muutosta tulee ohjata siten, että se on reilu kaikille osapuolille ja sen hyödyt kohdistuvat laajasti yhteiskuntaan. Tekoälyn ja robotiikan kehittämisessä ja vaikutusten arvioinnissa pitää huomioida väestön moninaisuus esimerkiksi sukupuolen, kielen, etnisyyden ja kehon suhteen.
+
+Tekoälyn ja robotiikan kehittämisen edellytyksistä on huolehdittava  
+Suomessa ja Euroopassa tulee tukea tekoälyä kehittävän ja hyödyntävän ekosysteemin muodostumista ja mahdollistaa reilu kilpailu. Tämä tarkoittaa muun muassa tutkimus- ja kehittämisrahoitusta, alan koulutuksen lisäämistä sekä järkevää sääntelyä jolla estetään datamonopolien syntymistä. On syytä varmistaa, ettei sääntely itsessään vahvista entuudestaan vahvoja yrityksiä, kuten teknologiajättejä, joilla on pieniä toimijoita enemmän voimavaroja mukautua sääntelyyn.
+
+**Tavoitteet:**
+
+*   Ohjataan tutkimus- ja kehittämisrahoitusta tekoälyn ja robotiikan kehittämiseen.
+*   Edistetään laadukkaiden yhteiskäyttöisten tietovarantojen tuottamista, avaamista ja ylläpitoa.
+*   Edistetään lainsäädännön ja innovaatiopolitiikan keinoin toimivaa kilpailua sekä ehkäistään erityisesti suljettujen datamonopolien syntymistä.
+
+**Erilaiset riskit eri tasoisella automaatiolla**  
+
+Kaikkea automaatiota ja tekoälyä ei voi niputtaa yhteen. Sääntelyä kehitettäessä on tärkeää huomioida järjestelmien autonomian aste. Lisäksi on huomioitava, ovatko järjestelmät ennalta määriteltyjä, niin sanottuja sääntöpohjaisia järjestelmiä, vai koneoppimiseen pohjautuvia järjestelmiä, jotka voivat käytön ja uuden datan myötä automaattisesti muuttaa toimintamallejaan.
+
+Suurimpia riski- ja epävarmuustekijöitä liittyy järjestelmiin, jotka oppivat automaattisesti ja toimivat itsenäisesti ilman ihmistä. Riskien suuruuteen vaikuttaa myös se, mihin tarkoitukseen automaatiota käytetään. Sääntelyn tulee olla sitä kireämpää, mitä suurempia vaikutuksia järjestelmällä on esimerkiksi ihmisten ja yhteisöjen perusoikeuksiin, ihmisten terveyteen sekä ympäristön tilaan. Korkean vaikuttavuuden käyttökohteissa tekoälyjärjestelmät eivät saa tehdä päätöksiä kokonaan automatisoidusti. Järjestelmien opettamiseen ja toiminnan varmistamiseen käytettävän tietopohjan pitää pysyä luotettavana, vapaana vinouttavista asenteista ja eettisesti kestävänä.
+
+**Tavoitteet:**
+
+*   Perustetaan tekoälysääntely riskipohjaisuuteen. Suomi on omalla esimerkillään aktiivisesti mukana EU-tasoisen riskipohjaisen tekoälysääntelyn kehittämisessä.
+*   Luodaan ja ylläpidetään korkeimman riskiluokan päätösalgoritmeista rekisteri, jossa avataan, miten tekoälyjärjestelmä toimii, mitä tietoa se käyttää päättelyyn, kuka järjestelmän on kehittänyt ja kuka sitä tai sitä kouluttavaa opetusaineistoa ylläpitää.
+*   Käynnistetään valmistelutyö, jonka tuloksena voidaan ennakoivasti ottaa kantaa koneoppivien järjestelmien hyödyntämiseen julkishallinnon päätöksenteossa.
+
+**Syrjimättömyys ja oikeusturva automaattisessa päätöksenteossa**
+
+Perus- ja ihmisoikeuksien sekä laissa määritellyn syrjintäkiellon on pädettävä riippumatta siitä, onko järjestelmissä tekoälyä vai ei. Erilaisten sensorien, algoritmien ja rekisterien autoritaarinen, kontrolloiva ja manipuloiva käyttö on siksi tuomittavaa. Ihmisten massavalvonta, esimerkiksi julkisilla paikoilla ja biometrisen tunnistamisen avulla on kiellettävä. Tämä mahdollistaa tekoälyn sääntelyn kehittämisen ennen ihmisten yksityisyydensuojaa ja oikeusturvaa vaarantavien sovellusten kehittämistä. Automatisoiduissa prosesseissa olevat syrjivät käytännöt leviävät helposti koskemaan laajoja joukkoja. Toisaalta syrjintää on ilman algoritmejakin, ja koneoppimista voidaan myös hyödyntää piilosyrjinnän tunnistamiseen.
+
+Kuluttajansuojan ja yleisen oikeusturvan toteutuminen edellyttää, että automaattisen päätöksenteon kohteella on mahdollisuus ymmärtää päätöksen perusteet. Virheellisten päätösten kyseenalaistaminen on mahdollista vain, jos automaattisesta päätöksenteosta kerrotaan avoimesti ja päätöksille on osoitettavissa selkeä vastuutaho.
+
+**Tavoitteet:**
+
+*   Perustetaan viranomaisten yhteistyötä ja osaamisen kehittämistä tukemaan määräaikainen, keskeisten valvovien viranomaisten (tietosuojavaltuutetun toimisto, kuluttaja- ja kilpailuvirasto, yhdenvertaisuusvaltuutetun toimisto) yhteinen tekoäly- ja robotiikkatiimi.
+*   Varmistetaan, että automaattisen päätöksenteon kohteella on mahdollisuus ymmärtää päätöksen perusteet. Jokaisen pitää myös voida valittaa vääristä päätöksistä sekä vaikuttaa itseään koskevaan päätöksentekoon tulevaisuudessa.
+*   Otetaan käyttöön tekoälymenetelmiä syrjintään viittaavien tilastopoikkeamien havaitsemiseen julkishallinnon päätösprosesseissa.  
+    Kielletään kasvojentunnistukseen tai vastaaviin biometrisiin tunnisteisiin pohjautuva massavalvonta julkisilla paikoilla.
+
+## DIGITALISAATION YMPÄRISTÖVAIKUTUKSET
+
+Tuomme poliittiseen keskusteluun **realistista kokonaiskuvaa digitalisaation myönteisistä ja kielteisistä ympäristövaikutuksista**, jotta nämä voidaan kattavasti huomioida päätöksenteossa.
+
+Digitalisaation tarjoamat mahdollisuudet ympäristö- ja ilmastokriisin ratkaisussa ovat mittavia. Digitalisaation avulla toimintoja voidaan tehostaa, materiaalisia tuotteita korvata digitaalisilla ja vähentää tarvetta liikkumiseen. Se on keskeinen elementti esimerkiksi kiertotalouden toimintamalleissa ja sen avulla voidaan edistää ympäristönsuojelua tuottamalla parempaa ympäristön tilannekuvaa, havaitsemalla globaaleja päästölähteitä ja toteuttamalla tehokasta maankäytön ohjausta datapohjaisesti. Digitaalisella toiminnalla on myös fyysinen ulottuvuus muun muassa datakeskusten, tietoverkkojen ja digitaalisten laitteiden tuotannon, ja niiden avulla tuotettujen palvelujen käytön kautta. Elektroniikan tuotantoketjussa on myös vakaviakin ihmsioikeusloukkauksia on niin kaivuuteollisuudessa, laitteiden tuotannossa kuin elektroniikkajätteen dumppauksessa. Lisäksi digitalisaatiolla on epäsuoria ympäristövaikutuksia, jotka voivat aiheuttaa tai kiihdyttää ympäristölle haitallisia kehityskulkuja tai hidastaa ympäristölle hyödyllistä kehitystä. Jotta digitaalinen yhteiskunta on kestävä, on ICT-infrastruktuurin energiatehokkuutta ja resurssitehokkuutta parannettava sekä edistettävä kestävyyttä parantavia digitaalisia ratkaisuja.
+
+Tutkittua tietoa digitalisaation kokonaisympäristövaikutuksista on vielä vähän. Saatavilla olevat tutkimukset ovat hajanaisia, heikosti vertailukelpoista ja hajonta tutkimustuloksissa on suurta. On kuitenkin selvää, että digitalisaation sekä myönteiset että kielteiset ympäristövaikutukset ovat suuruusluokaltaan niin merkittäviä, että ne on syytä ottaa vakavasti.
+
+**Digitalisaation fyysinen ulottuvuus**
+
+Pariisin ilmastosopimus edellyttää päästöjen nopeaa vähentämistä, mutta ICT-alan päästöt ja energiankulutus ovat merkittävässä kasvussa. Sektorin negatiiviset ympäristövaikutukset tulevat pääosin datakeskuksista ja datan käytöstä sekä elektroniikan valmistuksesta ja käytöstä. Datan kysyntä on kasvanut eksponentiaalisesti, mutta tähän mennessä datakeskusten energiatehokkuuden kehitys on pitänyt sähkönkulutuksen nousun aisoissa. Elektroniikan resurssikierto ja kierrätys ovat vielä suurelta osin ratkaisemattomia kysymyksiä.
+
+ICT-sektorin päästövähennysten kannalta olennaista on, millä tavalla kulutettu energia tuotetaan. Seurataan kasvavaa laskentatehoa vaativien teknologioiden, kuten joidenkin kryptovaluuttojen käytön kehitystä ja arvioidaan tarvetta energiankulutusta hillitseville ratkaisuille ja rajoituksille. Päästövähennysten kannalta olennaista on, millä tavalla kulutettu energia tuotetaan. Julkisten organisaatioiden tulisi omissa pilvipalvelujen hankinnoissaan kiinnittää huomiota datakeskusten ympäristöystävällisyyteen ja siten edistää palveluntarjoajien siirtymistä uusiutuvaan energiaan. Datakeskusten hukkalämmön hyödyntämisellä on suuri vaikutus alan kokonaispäästöihin. Datakeskuksiin voidaan kohdistaa kansallisella tasolla vaatimuksia esimerkiksi vihreän energian käytöstä sekä lämmön talteenotosta, kunhan varmistetaan, etteivät vaatimukset johda ympäristön kannalta heikompien datakeskusten rakentamiseen muualle.
+
+Materiaalisen ympäristöjalanjäljen pienentämiseksi elektroniikan käyttöikää on pidennettävä, raaka-aineiden käyttöä ja kiertoa on tehostettava sekä suosittava vähiten haitallisten materiaalien käyttöä. Materiaalien kiertoa voidaan edistää taloudellisten kannustimien, kuten verotuksen ja panttijärjestelmien avulla. Samalla on varmistettava laitteiden kierrätyksen ja uusiokäytön tietoturva. Neitseellisten luonnonvarojen käytön minimoimiseksi tulee tukea elektroniikan kiertotalouden sovellutuksia ja yritystoimintaa. Laitteiden käyttöikää voidaan pidentää luomalla “oikeus korjata” -ajattelun mukaista kuluttajalainsäädäntöä. Sillä taataan kuluttajille ja yritysasiakkaille oikeus ja mahdollisuus tuotteen korjauttamiseen, vaihto-osiin sekä päivityksiin kohtuullisin kustannuksin.
+
+Dataintensiivisten kuluttajapalvelujen jatkuvasti kasvava käyttö on keskeisin syy data- ja laskentakapasiteetin kysynnän kasvuun. Digitaalisille palveluille tulee luoda samanlainen kuluttajansuojalainsäädäntö kuin fyysisille tuotteille (vrt. elintarvikkeiden tuoteselosteet). Ympäristötietoisempien valintojen pohjaksi digitaalisten palvelujen tuotekuvauksiin tulee sisällyttää yksityisyyden suojan ja datan käsittelyn lisäksi myös palvelujen ympäristövaikutukset.
+
+**Tavoitteet:**
+
+*   Hyödynnetään datakeskusten hukkalämpö osana energiataloutta. Edellytetään datakeskusten energiankulutuksen julkistamista viranomaisille ja varmistetaan, että datakeskusten, tietoverkkojen ja päätelaitteiden kasvava sähkön tarve katetaan päästöttömällä energialla ja parantamalla energiatehokkuutta.
+*   Luodaan lainsäädäntö kulutuselektroniikan kattavan “oikeus korjata” -ajattelun ympärille ja kielletään elektroniikkalaitteiden tarkoituksellinen vanhentaminen.
+*   Kehitetään elektroniikan kierrätysasteen parantamiseksi ja kiertotalouden edistämiseksi sopivia kannustimia, sääntelyä ja infrastruktuuria.
+*   Parannetaan kuluttajien tietoisuutta elektroniikan ja digitaalisten palvelujen ympäristövaikutuksista. Edellytetään, että yritykset tarjoavat riittävää tuoteinformaatiota elektroniikan ja digitaalisten palvelujen ympäristövaikutuksista.
+*   Otetaan käyttöön kunnianhimoinen yritysvastuulaki sekä Suomen että EU:n tasolla. Varmistetaan läpinäkyvyys ja työntekijöiden oikeudet tuotantoketjun kaikissa vaiheissa.
+
+**Digitalisaatio ympäristökriisin ratkaisemisessa**
+
+Digitalisaation avulla voidaan säästää energiaa ja resursseja tuotantoketjujen eri vaiheissa ja luoda mahdollisuuksia muiden sektorien energiankäytön vähentämiseen. Lisäksi digitalisaation avulla voidaan suoraan edistää ympäristönsuojelua esimerkiksi tuottamalla parempaa ympäristön tilannekuvaa. Valtion tulee edesauttaa yritysten siirtymistä kohti kestäviä liiketoimintamalleja digitalisaation tuomien välineiden avulla. Kehittyneen digitaalisen arvoketjujen mallintamiseen avulla voidaan tarjota kuluttajille parempaa tietoa tuotteiden ja palvelujen ympäristövaikutuksista. Omassa toiminnassaan julkishallinnon tulee avoimesti mallintaa omien hankintaketjujensa ympäristövaikutukset.
+
+Kattava ja reaaliaikainen tieto ympäristön tilasta on edellytys ympäristöongelmien ratkaisemiseksi. Sensoridatan ja laskennallisten mallinnusmenetelmien avulla voidaan esimerkiksi ohjata maankäyttöä ja hiilinielujen hoitoa kohdennetusti. Lisäksi voidaan seurata muutoksia biodiversiteettissä ja ekosysteemien toiminnassa jopa reaaliaikaisilla mittareilla. Jotta datapohjaisen ympäristönsuojelun ja maankäytön ohjauksen edellyttämät tietovarannot saadaan nopeasti käyttöön, on ympäristön tilan automatisoituun seurantaan varattava riittävä rahoitus. Samalla voidaan luoda mahdollisuuksia kansalaistoiminnalle ja uudelle liiketoiminnalle tarjoamalla tietoaineistot ja laskentamallit maksutta ja avoimesti kansalaisille ja yrityksille.
+
+**Tavoitteet:**
+
+*   Tuetaan yritysten siirtymistä kohti ekologisesti kestäviä liiketoimintamalleja.
+*   Panostetaan julkisten hankintojen arvoketjujen mallintamiseen ja ympäristövaikutusten arviointiin. Tehdään arvoketjuista ja niiden mallinnustyökaluista julkisia.
+*   Seurataan ilmastonmuutoksen, luontokadon ja muiden ympäristöongelmien ja niiden torjuntatoimien etenemistä ja vaikutuksia keräämällä reaaliaikaista ja kattavaa dataa sekä julkaisemalla sitä avoimesti. Varataan riittävä rahoitus ympäristön tilan automatisoituun seurantaan.


### PR DESCRIPTION
Muutettu tämän sivun sisältö markdowniksi https://www.vihreat.fi/tietopoliittinen-ohjelma/

En laittanut vielä alkuun layout, title ja description tietoja.

Sisällysluettelo linkittää nyt web-sivulle, kun voisi linkittää markdownissa oikeisiin kohtiin.